### PR TITLE
Fix typo: vaildation -> validation

### DIFF
--- a/src/dataflex/offline_selector/offline_near_selector.py
+++ b/src/dataflex/offline_selector/offline_near_selector.py
@@ -179,7 +179,7 @@ class offline_near_Selector:
 if __name__ == "__main__":
     near = offline_near_Selector(
         candidate_path="OpenDCAI/DataFlex-selector-openhermes-10w", # split = train
-        query_path="OpenDCAI/DataFlex-selector-openhermes-10w", # split = vaildation
+        query_path="OpenDCAI/DataFlex-selector-openhermes-10w", # split = validation
         # It automatically try vllm first, then sentence-transformers
         embed_model="Qwen/Qwen3-Embedding-0.6B",
         # support method:


### PR DESCRIPTION
## Summary
Fixed spelling typo in `src/dataflex/offline_selector/offline_near_selector.py:182`

- Changed `vaildation` to `validation` in comment

## Related Issue
Closes #38

## Type of Change
- [x] Bug fix (typo correction)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update